### PR TITLE
docs(dependabot-rebase-cascade): clarify branches filter comment for workflow_run

### DIFF
--- a/.github/workflows/dependabot-rebase-cascade.yml
+++ b/.github/workflows/dependabot-rebase-cascade.yml
@@ -4,7 +4,10 @@ on:
   workflow_run:
     workflows: ["Dependabot reviewer"]
     types: [completed]
-    branches: [main]
+    # No branches filter: "Dependabot reviewer" runs on pull_request_target,
+    # so its head_branch is the dependabot/* branch, never main — a
+    # branches:[main] filter here would never match and this job would
+    # never fire.
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
- Clarify the comment regarding the branches filter in the workflow_run section.

- Explain that the "Dependabot reviewer" workflow runs on pull_request_target, making the branches filter unnecessary.