### PR TITLE
fix(ci): use PAT for dependabot rebase comments and guard against re-trigger loop

### DIFF
--- a/.github/workflows/dependabot-rebase-cascade.yml
+++ b/.github/workflows/dependabot-rebase-cascade.yml
@@ -19,17 +19,24 @@ jobs:
     # Only fire when the reviewer workflow approved and merged (conclusion = success)
     if: github.event.workflow_run.conclusion == 'success'
     env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Dependabot only honors @dependabot commands from a commenter with
+      # push access. A GITHUB_TOKEN-authored comment (github-actions[bot])
+      # is silently rejected ("only users with push access"), which used to
+      # make this job re-comment on every PR on every run forever without
+      # ever actually rebasing anything. DEPENDABOT_REBASE_PAT must be a PAT
+      # (classic or fine-grained with pull-requests:write) or GitHub App
+      # installation token belonging to an account with push access.
+      GITHUB_TOKEN: ${{ secrets.DEPENDABOT_REBASE_PAT }}
 
     steps:
-      - name: Rebase remaining open Dependabot PRs
+      - name: Rebase stale/diverged open Dependabot PRs
         run: |
           gh pr list \
             --repo "${{ github.repository }}" \
             --author "app/dependabot" \
             --state open \
-            --json number \
-            --jq '.[].number' | \
+            --json number,mergeStateStatus \
+            --jq '.[] | select(.mergeStateStatus == "BEHIND" or .mergeStateStatus == "BLOCKED" or .mergeStateStatus == "DIRTY") | .number' | \
           while read -r pr; do
             echo "Requesting rebase on PR #$pr"
             gh pr comment "$pr" \

--- a/.github/workflows/dependabot-rebase-cascade.yml
+++ b/.github/workflows/dependabot-rebase-cascade.yml
@@ -4,7 +4,10 @@ on:
   workflow_run:
     workflows: ["Dependabot reviewer"]
     types: [completed]
-    branches: [main]
+    # No branches filter: "Dependabot reviewer" runs on pull_request_target,
+    # so its head_branch is the dependabot/* branch, never main — a
+    # branches:[main] filter here would never match and this job would
+    # never fire.
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary
- Dependabot rejects @dependabot rebase comments authored by GITHUB_TOKEN (github-actions[bot]) with "only users with push access can use that command" — this previously caused dependabot-rebase-cascade.yml to loop indefinitely without ever succeeding.
- Switch the workflow to use a PAT secret (DEPENDABOT_REBASE_PAT) with real push access instead of GITHUB_TOKEN.
- Only comment on PRs that are actually BEHIND/BLOCKED/DIRTY instead of every open Dependabot PR on every run, as a guard against re-triggering itself.

## Test plan
- [ ] Add DEPENDABOT_REBASE_PAT repo secret (fine-grained PAT scoped to this repo, Pull requests: Read and write)
- [ ] Merge this PR
- [ ] Re-enable the workflow: gh workflow enable "Dependabot stale rebase"
- [ ] Confirm next Dependabot PR run: comment posts once, Dependabot accepts it, no loop